### PR TITLE
Add support for the `/users` endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Initialization parameters:
 
 **Methods**
 
+`get_user(user_id)`
+
+Get a user by ID. Returns a single User object.
+
 `get_teams(limit=None, after=None)`
 
 List teams that you have access to. Returns list of Team objects.
@@ -147,6 +151,16 @@ Alias for `delete_item` method, works the same.
 `get_file(file_id)`
 
 Get a file by ID. Returns a single File instance.
+
+### User
+
+**Atrributes**
+
+* `id` (str) — user ID,
+* `first_name` (str) — user's first name,
+* `last_name` (str) — user's last name,
+* `email` (str) — user's email address 
+* `avatar_url` Optional(str) — URL address of the user's avatar image. None if the user has not set an avatar. 
 
 ### Team
 

--- a/nuclino/api.py
+++ b/nuclino/api.py
@@ -127,6 +127,18 @@ class Client:
 
 
 class Nuclino(Client):
+
+    def get_user(self, user_id: str):
+        '''
+        Get information associated with a specific user by ID.
+
+        :param user_id: ID of the user to get.
+
+        '''
+
+        path = f'/users/{user_id}'
+        return self.get(path)
+
     def get_teams(
         self,
         limit: Optional[int] = None,
@@ -285,7 +297,7 @@ class Nuclino(Client):
         :returns: the created Item or Collection object.
         '''
 
-        path = f'/items'
+        path = '/items'
         data = {'object': object}
         if workspace_id is not None:
             data['workspaceId'] = workspace_id

--- a/nuclino/api.py
+++ b/nuclino/api.py
@@ -128,12 +128,13 @@ class Client:
 
 class Nuclino(Client):
 
-    def get_user(self, user_id: str):
+    def get_user(self, user_id: str) -> Union[List, NuclinoObject, dict]:
         '''
         Get information associated with a specific user by ID.
 
         :param user_id: ID of the user to get.
 
+        :returns: a User object
         '''
 
         path = f'/users/{user_id}'

--- a/nuclino/objects.py
+++ b/nuclino/objects.py
@@ -17,6 +17,21 @@ class NuclinoObject:
         self.data = dict(props)
         self.nuclino = nuclino
 
+class User(NuclinoObject):
+    _object = "user"
+
+    def __init__(self, props: dict, nuclino):
+        super().__init__(props, nuclino)
+
+        self.id = props['id']
+        self.first_name = props['firstName']
+        self.last_name = props['lastName']
+        self.email = props['email']
+        self.avatar_url = props['avatarUrl']
+
+    def __repr__(self) -> str:
+        return f'<User "{self.first_name} {self.last_name}">'
+
 
 class Team(NuclinoObject):
     _object = "team"

--- a/nuclino/objects.py
+++ b/nuclino/objects.py
@@ -27,7 +27,7 @@ class User(NuclinoObject):
         self.first_name = props['firstName']
         self.last_name = props['lastName']
         self.email = props['email']
-        self.avatar_url = props['avatarUrl']
+        self.avatar_url = props.get('avatarUrl')
 
     def __repr__(self) -> str:
         return f'<User "{self.first_name} {self.last_name}">'

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -54,6 +54,11 @@ class TestParse(TestCase):
         data = {"id": "1034eebc-b96a-42b7-92ea-6795d6440fda"}
         result = self.client.parse(data)
         self.assertEqual(result, data)
+    
+    def test_user(self):
+        data = open_data_file('get_user.json')
+        result = self.client.parse(data['data'])
+        self.assertIsInstance(result, objects.User)
 
     def test_team(self):
         data = open_data_file('get_team.json')

--- a/test/test_data/get_user.json
+++ b/test/test_data/get_user.json
@@ -1,0 +1,11 @@
+{
+  "status": "success",
+  "data": {
+    "object": "user",
+    "id": "9bff403a-6e0a-4f17-beac-c4333bd719b4",
+    "firstName": "Thomas",
+    "lastName": "Anderson",
+    "email": "thomas@nuclino.com",
+    "avatarUrl": "https://files.nuclino.com/avatars/9bff403a-6e0a-4f1..."
+  }
+}

--- a/test/test_live.py
+++ b/test/test_live.py
@@ -2,7 +2,7 @@
 These tests call live API and require API_KEY env var to be set.
 Beware of rate limiting while running these tests.
 At the time of writing there's a limit of 150 requests per minute.
-This test suite runs 34 requests.
+This test suite runs 36 requests.
 
 WARNING: These tests create test entities (and then delete them) in
 one of your workspaces.
@@ -48,6 +48,14 @@ class TestTeams(TestCaseWithKey):
         team_id = teams[0].id
         result = self.client.get_team(team_id)
         self.assertIsInstance(result, objects.Team)
+
+
+class TestUser(TestCaseWithKey):
+    def test_normal(self):
+        teams = self.client.get_teams() #1req
+        user_id = teams[0].createdUserId
+        result = self.client.get_user(user_id) #1req
+        self.assertIsInstance(result, objects.User)
 
 
 class TestWorkspaces(TestCaseWithKey):

--- a/test/test_live.py
+++ b/test/test_live.py
@@ -53,7 +53,7 @@ class TestTeams(TestCaseWithKey):
 class TestUser(TestCaseWithKey):
     def test_normal(self):
         teams = self.client.get_teams() #1req
-        user_id = teams[0].createdUserId
+        user_id = teams[0].created_user_id
         result = self.client.get_user(user_id) #1req
         self.assertIsInstance(result, objects.User)
 


### PR DESCRIPTION
Adds the `GET /v0/users/:id` endpoint as documented here: https://help.nuclino.com/f76dc920-users